### PR TITLE
HMAC-based handshake authentication

### DIFF
--- a/core/crypto.py
+++ b/core/crypto.py
@@ -2,6 +2,8 @@
 Core cryptographic functions for MST VPN.
 Uses PyNaCl (libsodium) for secure random byte generation.
 """
+import hmac
+import hashlib
 from nacl.utils import random
 from nacl.secret import SecretBox
 from nacl.exceptions import CryptoError
@@ -12,6 +14,7 @@ from cryptography.hazmat.primitives import hashes
 PSK_SIZE = 32  # 256 bits = 32 bytes (standard for ChaCha20)
 NONCE_SIZE = 24  # PyNaCl SecretBox uses 24-byte nonces
 SESSION_KEY_SIZE = 32
+MAC_SIZE = 32  # HMAC-SHA256 produces 32-byte output
 HKDF_INFO= b'MST-v1-session-key'
 def generate_psk():
     """
@@ -101,3 +104,87 @@ def decrypt_data(session_key, ciphertext, nonce):
         return plaintext
     except CryptoError:
         raise CryptoError("Decryption failed: data may be tampered")
+    
+def compute_handshake_mac(psk, client_nonce, server_nonce):
+    """
+        Compute HMAC for handshake authentication.
+    This function creates a "proof" that the caller knows the PSK.
+    An attacker without the PSK cannot create a valid MAC.
+    The MAC is computed over both nonces to:
+        1. Ensure freshness (nonces are random each time)
+        2. Bind this MAC to this specific handshake
+        3. Prevent replay attacks (old MACs can't be reused)
+    Args:
+            psk (bytes): Pre-shared key (32 bytes)
+            client_nonce (bytes): Client's random nonce (24 bytes)
+            server_nonce (bytes): Server's random nonce (24 bytes)
+        Returns:
+            bytes: HMAC-SHA256 (32 bytes)
+        Raises:
+    ValueError: If any input has wrong length
+        Security Note:
+    The order of nonces in the message MUST be consistent:
+            always client_nonce || server_nonce. If client and server
+            use different orders, MACs won't match and handshake fails.
+        """
+    # Validate inputs
+    if len(psk) != PSK_SIZE:
+        raise ValueError(f"PSK must be {PSK_SIZE} bytes")
+    if len(client_nonce) != NONCE_SIZE:
+        raise ValueError(f"Client nonce must be {NONCE_SIZE} bytes")
+    if len(server_nonce) != NONCE_SIZE:
+        raise ValueError(f"Server nonce must be {NONCE_SIZE} bytes")
+    
+    # Construct the message: client nonce comes FIRST (standardized order)
+    # This is the data we're "signing" with the PSK
+    message = client_nonce + server_nonce  # 48 bytes total
+    
+    # Compute HMAC-SHA256
+    # hmac.new(key, message, hash_algorithm)
+    mac = hmac.new(
+        psk,       # Secret key (only client and server know this)       
+        message,   # Data to authenticate (both nonces)
+        hashlib.sha256     # Hash function (SHA-256)
+    ).digest()           # Get raw bytes (not hex string)
+    
+    # MAC is 32 bytes (256 bits from SHA-256)
+    assert len(mac) == 32, "HMAC-SHA256 should produce 32 bytes"
+    
+    return mac
+
+def verify_handshake_mac(psk, client_nonce, server_nonce, received_mac):
+    """
+    Verify a handshake MAC is correct.
+    
+    This checks if the received MAC matches what we expect.
+    If MACs match: other side knows the PSK (authentic!)
+    If MACs don't match: other side doesn't know PSK (imposter!)
+    
+    Args:
+        psk (bytes): Pre-shared key (32 bytes)
+        client_nonce (bytes): Client's nonce (24 bytes)
+        server_nonce (bytes): Server's nonce (24 bytes)
+        received_mac (bytes): MAC received from other side (32 bytes)
+        
+    Returns:
+        bool: True if MAC is valid, False otherwise
+        
+    Security Critical:
+        Uses timing-safe comparison to prevent timing attacks.
+        Regular comparison (==) might leak information about
+        how many bytes matched, helping attackers guess the MAC.
+    """
+    # Validate received MAC length
+    if len(received_mac) != MAC_SIZE:
+        # Don't even try to verify if wrong size
+        return False
+    
+    # Compute what the MAC SHOULD be
+    expected_mac = compute_handshake_mac(psk, client_nonce, server_nonce)
+    
+    # Compare using timing-safe function
+    # hmac.compare_digest() takes same time regardless of how many bytes match
+    # Regular comparison (==) returns faster if first bytes don't match
+    is_valid = hmac.compare_digest(received_mac, expected_mac)
+    
+    return is_valid

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3,8 +3,8 @@ import pytest
 from nacl.exceptions import CryptoError
 
 from core.crypto import (
-    generate_psk, generate_nonce, derive_session_key, encrypt_data, decrypt_data,
-    PSK_SIZE, NONCE_SIZE, SESSION_KEY_SIZE
+    generate_psk, generate_nonce, derive_session_key, encrypt_data, decrypt_data, compute_handshake_mac, verify_handshake_mac,
+    PSK_SIZE, NONCE_SIZE, SESSION_KEY_SIZE, MAC_SIZE
 )
 def test_generate_psk_returns_correct_size():
     """PSK should be exactly 32 bytes."""
@@ -110,3 +110,91 @@ def test_decrypt_tampered_ciphertext_fails():
     
     with pytest.raises(CryptoError):
         decrypt_data(session_key, tampered, nonce)
+
+def test_compute_handshake_mac_returns_correct_size():
+    """MAC should be 32 bytes (HMAC-SHA256 output)."""
+    psk = generate_psk()
+    client_nonce = generate_nonce()
+    server_nonce = generate_nonce()
+    mac = compute_handshake_mac(psk, client_nonce, server_nonce)
+    
+    assert len(mac) == MAC_SIZE  # 32 bytes
+    assert type(mac) == bytes
+    
+def test_compute_handshake_mac_is_deterministic():
+    """Same inputs should always produce same MAC."""
+    psk = generate_psk()
+    client_nonce = generate_nonce()
+    server_nonce = generate_nonce()
+    mac1 = compute_handshake_mac(psk, client_nonce, server_nonce)
+    mac2 = compute_handshake_mac(psk, client_nonce, server_nonce)
+    
+    assert mac1 == mac2  # Deterministic
+    
+def test_compute_handshake_mac_different_nonces_different_mac():
+    """Changing nonces should produce different MAC."""
+    psk = generate_psk()
+    client_nonce1 = generate_nonce()
+    client_nonce2 = generate_nonce()
+    server_nonce = generate_nonce()
+    mac1 = compute_handshake_mac(psk, client_nonce1, server_nonce)
+    mac2 = compute_handshake_mac(psk, client_nonce2, server_nonce)
+    
+    assert mac1 != mac2  # Different nonces = different MAC
+
+def test_verify_handshake_mac_accepts_valid_mac():
+    """Verification should succeed for correct MAC."""
+    psk = generate_psk()
+    client_nonce = generate_nonce()
+    server_nonce = generate_nonce()
+    # Compute valid MAC
+    mac = compute_handshake_mac(psk, client_nonce, server_nonce)
+    # Verify it
+    is_valid = verify_handshake_mac(psk, client_nonce, server_nonce, mac)
+    
+    assert is_valid == True
+    
+def test_verify_handshake_mac_rejects_wrong_mac():
+    """Verification should fail for incorrect MAC."""
+    psk = generate_psk()
+    client_nonce = generate_nonce()
+    server_nonce = generate_nonce()
+    # Create a completely wrong MAC
+    wrong_mac = b'\x00' * 32
+    # Verify it (should fail)
+    is_valid = verify_handshake_mac(psk, client_nonce, server_nonce, wrong_mac)
+    
+    assert is_valid == False
+
+def test_verify_handshake_mac_rejects_tampered_mac():
+    """Verification should fail if MAC is modified."""
+    psk = generate_psk()
+    client_nonce = generate_nonce()
+    server_nonce = generate_nonce()
+    # Compute valid MAC
+    mac = compute_handshake_mac(psk, client_nonce, server_nonce)
+    # Tamper with it (flip one bit)
+    tampered_mac = bytearray(mac)
+    tampered_mac[0] ^= 0x01  # Flip least significant bit
+    tampered_mac = bytes(tampered_mac)
+    
+    # Verify tampered MAC (should fail)
+    is_valid = verify_handshake_mac(psk, client_nonce, server_nonce, tampered_mac)
+    
+    assert is_valid == False
+
+def test_verify_handshake_mac_rejects_wrong_psk():
+    """Verification with different PSK should fail."""
+    psk1 = generate_psk()
+    psk2 = generate_psk()  # Different PSK
+    client_nonce = generate_nonce()
+    server_nonce = generate_nonce()
+    
+    # Compute MAC with PSK1
+    mac = compute_handshake_mac(psk1, client_nonce, server_nonce)
+    
+    # Try to verify with PSK2 (should fail)
+    is_valid = verify_handshake_mac(psk2, client_nonce, server_nonce, mac)
+    
+    assert is_valid == False
+    


### PR DESCRIPTION
- Implement compute_handshake_mac() using HMAC-SHA256
- Implement verify_handshake_mac() with timing-safe comparison
- Add MAC computation over both client and server nonces
- Add comprehensive test suite for MAC operations (7 tests)
- Tests verify: correct size, determinism, nonce changes, valid/invalid MACs, tampering detection

Security features:
- HMAC-SHA256 provides cryptographic authentication
- Timing-safe comparison prevents side-channel attacks
- Standardized nonce ordering (client || server) prevents MAC mismatches
- Input validation for all cryptographic operations